### PR TITLE
Remove temporary variable imgs_ from memory

### DIFF
--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -238,6 +238,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                         self.labels_img_, interpolation="nearest",
                         target_shape=imgs_.shape[:3],
                         target_affine=imgs_.affine)
+            del imgs_
 
         target_shape = None
         target_affine = None

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -238,6 +238,8 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                         self.labels_img_, interpolation="nearest",
                         target_shape=imgs_.shape[:3],
                         target_affine=imgs_.affine)
+            # Remove imgs_ from memory before loading the same image
+            # in filter_and_extract.
             del imgs_
 
         target_shape = None


### PR DESCRIPTION
transform_single_imgs loads a (potentially large) dataset into the imgs_ variable, potentially uses it for a couple of things, and then does not use it anymore. filter_and_extract, which gets called later in transform_single_imgs, loads the same 3D/4D scan into a different variable (local to filter_and_extract). This leads to two separate copies of a potentially large dataset being loaded into memory while transform_single_imgs runs. `del imgs_' ensures only a single copy is in memory at a time.